### PR TITLE
Use Git Version of Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "vibrant"
 version = "0.1.0"
 dependencies = [
- "clippy 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.15 (git+https://github.com/Manishearth/rust-clippy.git)",
  "color_quant 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -30,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "clippy"
 version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/Manishearth/rust-clippy.git#4838e8a3b4539ffc7feb9bfa2e2c72b00c55f0b5"
 dependencies = [
  "unicode-normalization 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ dev = ["clippy"]
 image = "0.3.12"
 color_quant = "1.0"
 itertools = "0.3"
-clippy = { version = "0.0.15", optional = true }
+clippy = { git = "https://github.com/Manishearth/rust-clippy.git", optional = true }

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -26,6 +26,7 @@ impl HSL {
     }
 
     /// Convert RGB pixel (as array of three bytes) to HSL.
+    #[cfg_attr(feature = "dev", allow(float_cmp))]
     fn from_rgb(rgb: &[u8]) -> HSL {
         let mut h: f64;
         let s: f64;
@@ -109,6 +110,7 @@ fn percent_to_byte(percent: f64) -> u8 {
 }
 
 fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
+    // Normalize
     let t = if t < 0.0 {
         t + 1.0
     } else if t > 1.0 {
@@ -117,7 +119,7 @@ fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
         t
     };
 
-    let res = if t < 1.0 / 6.0 {
+    if t < 1.0 / 6.0 {
         p + (q - p) * 6.0 * t
     } else if t < 1.0 / 2.0 {
         q
@@ -125,9 +127,7 @@ fn hue_to_rgb(p: f64, q: f64, t: f64) -> f64 {
         p + (q - p) * (2.0 / 3.0 - t) * 6.0
     } else {
         p
-    };
-
-    res
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Faster updates for a dependency that requires nightlies seem like a good
idea.
